### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        'nltk', 'joblib', 'sklearn_crfsuite', 'fuzzywuzzy', 'python-Levenshtein'
+        'nltk', 'joblib', 'sklearn_crfsuite', 'rapidfuzz'
     ],
     include_package_data=True,
 )

--- a/vnaddress/functions/spell_correction_layer/match_word.py
+++ b/vnaddress/functions/spell_correction_layer/match_word.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 
 
 def match_word(error_dict, word_to_check, standard_single_names):
@@ -9,7 +9,7 @@ def match_word(error_dict, word_to_check, standard_single_names):
         name_to_check = word_to_check
         # standard_single_names_lower = [name.lower() for name in standard_single_names]
         if name_to_check not in standard_single_names:
-            extraction = (process.extractOne(name_to_check, error_dict[key], scorer=fuzz.ratio))
+            extraction = process.extractOne(name_to_check, error_dict[key], scorer=fuzz.ratio)
             if extraction[1] > weight:
                 # print(weight, key, name_to_check)
                 weight = extraction[1]
@@ -30,7 +30,7 @@ def match_sentence(error_dict, sentence_to_check, standard_addresses):
         # name_to_check = sentence_to_check
         # standard_single_names_lower = [name.lower() for name in standard_single_names]
         if sentence_to_check not in standard_addresses:
-            extraction = (process.extractOne(sentence_to_check, error_dict[key], scorer=fuzz.ratio))
+            extraction = process.extractOne(sentence_to_check, error_dict[key], scorer=fuzz.ratio)
             if extraction[1] > weight:
                 # print(weight, key, name_to_check)
                 weight = extraction[1]

--- a/vnaddress/parser.py
+++ b/vnaddress/parser.py
@@ -3,7 +3,7 @@ import multiprocessing as mp
 import os
 from os.path import dirname, join
 
-from fuzzywuzzy import process, fuzz
+from rapidfuzz import process, fuzz
 
 from .constants import ERROR_DICT, SINGLE_VOWELS, STANDARD_ADDRESSES, STANDARD_SINGLE_NAMES, FULL_ADDRRESS_ERROR_DICT
 from .functions.acronym_layer import acronym_execute


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy